### PR TITLE
Multipart fixes

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -22,7 +22,7 @@ if Code.ensure_loaded?(:hackney) do
     defp request(method, url, headers, %Stream{} = body, opts), do: request_stream(method, url, headers, body, opts)
     defp request(method, url, headers, body, opts) when is_function(body), do: request_stream(method, url, headers, body, opts)
     defp request(method, url, headers, %Multipart{} = mp, opts) do
-      headers = Keyword.merge(headers, Multipart.headers(mp))
+      headers = headers ++ Multipart.headers(mp)
       body = Multipart.body(mp)
 
       request(method, url, headers, body, opts)

--- a/lib/tesla/adapter/httpc.ex
+++ b/lib/tesla/adapter/httpc.ex
@@ -42,7 +42,7 @@ defmodule Tesla.Adapter.Httpc do
   end
 
   defp request(method, url, headers, _content_type, %Multipart{} = mp, opts) do
-    headers = Keyword.merge(headers, Multipart.headers(mp))
+    headers = headers ++ Multipart.headers(mp)
     headers = for {key, value} <- headers, do: {to_charlist(key), to_charlist(value)}
     {content_type, headers} = Keyword.pop_first(headers, 'Content-Type', 'text/plain')
     body = stream_to_fun(Multipart.body(mp))

--- a/lib/tesla/adapter/ibrowse.ex
+++ b/lib/tesla/adapter/ibrowse.ex
@@ -23,7 +23,7 @@ if Code.ensure_loaded?(:ibrowse) do
     end
 
     defp request(url, headers, method, %Multipart{} = mp, opts) do
-      headers = Keyword.merge(headers, Multipart.headers(mp))
+      headers = headers ++ Multipart.headers(mp)
       body = stream_to_fun(Multipart.body(mp))
 
       request(url, headers, method, body, opts)

--- a/lib/tesla/middleware/form_urlencoded.ex
+++ b/lib/tesla/middleware/form_urlencoded.ex
@@ -33,7 +33,9 @@ defmodule Tesla.Middleware.FormUrlencoded do
 
   defp encode_body(body, _opts), do: do_process(body)
 
-  def encodable?(env), do: env.body != nil
+  def encodable?(%{body: nil}),                 do: false
+  def encodable?(%{body: %Tesla.Multipart{}}),  do: false
+  def encodable?(_),                            do: true
 
   defp do_process(data) do
     URI.encode_query(data)

--- a/lib/tesla/middleware/json.ex
+++ b/lib/tesla/middleware/json.ex
@@ -41,7 +41,9 @@ defmodule Tesla.Middleware.JSON do
     Stream.map body, fn item -> encode_body(item, opts) <> "\n" end
   end
 
-  def encodable?(env), do: env.body != nil
+  def encodable?(%{body: nil}),                 do: false
+  def encodable?(%{body: %Tesla.Multipart{}}),  do: false
+  def encodable?(_),                            do: true
 
   def decode(env, opts) do
     if decodable?(env, opts) do


### PR DESCRIPTION
This PR addresses the 2 issues that I mentioned in https://github.com/teamon/tesla/pull/87

1. Appends the multipart headers to the main request instead of merging
This potentially loses the ability to overwrite duplicated headers
2. Modifies the json and form url encoders to not attempt to encode the `Multipart` body.